### PR TITLE
add missing "delay" parameter in exampleconfig.json

### DIFF
--- a/exampleconfig.json
+++ b/exampleconfig.json
@@ -54,6 +54,7 @@
 	},
 	"retryagent": {
 		"type": "filesystem",
+		"delay": 60,
 		"path": "/tmp/idlemail_retryagent"
 	}
 }


### PR DESCRIPTION
Without this parameter idlemail crashes immediately at startup.